### PR TITLE
Add fastqc, khtools, move all installation into environment.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * Update Dockerfile with sourmash compute bam input dependencies
 * Add "fastp" to container requirements
 * Update Dockerfile with sourmash compute bam input dependencies
-* Update Dockerfile with [czbiohub/khtools](https://github.com/czbiohub/kh-tools/) repo
 
 ## v1.0 - 6 March 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add fastqc to environment.yml
 * Add [czbiohub/khtools](https://github.com/czbiohub/kh-tools/) repo to environment.yml
 * Update Dockerfile with sourmash compute bam input dependencies
+* Add "fastp" to container requirements
 
 ## v1.0 - 6 March 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 * Add option to use Dayhoff encoding for sourmash
 * Add bam file process to kmermaid pipeline and optional params
   for the same
-* Update dockerfile with sourmash compute bam input dependencies
+
+### Dependency updates
+* Update Dockerfile with sourmash compute bam input dependencies
+* Update Dockerfile with [czbiohub/khtools](https://github.com/czbiohub/kh-tools/) repo
 
 ## v1.0 - 6 March 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
   for the same
 
 ### Dependency updates
+* Add fastqc to environment.yml
+* Add [czbiohub/khtools](https://github.com/czbiohub/kh-tools/) repo to environment.yml
 * Update Dockerfile with sourmash compute bam input dependencies
-* Update Dockerfile with [czbiohub/khtools](https://github.com/czbiohub/kh-tools/) repo
 
 ## v1.0 - 6 March 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Add [czbiohub/khtools](https://github.com/czbiohub/kh-tools/) repo to environment.yml
 * Update Dockerfile with sourmash compute bam input dependencies
 * Add "fastp" to container requirements
+* Update Dockerfile with sourmash compute bam input dependencies
+* Update Dockerfile with [czbiohub/khtools](https://github.com/czbiohub/kh-tools/) repo
 
 ## v1.0 - 6 March 2019
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,36 +7,9 @@ ARG BUILD_DATE
 LABEL org.label-schema.vcs-ref=$VCS_REF \
 org.label-schema.vcs-url="e.g. https://github.com/nf-core/kmermaid"
 
-# WORKDIR /home
-#
-# ENV PACKAGES zlib1g git g++ make ca-certificates gcc zlib1g-dev libc6-dev procps libbz2-dev libcurl4-openssl-dev libssl-dev
-#
-# # Sourmash requires last 3 of the above apt packages for installation of htslib in pysam
-#
-# ### don't modify things below here for version updates etc.
-#
-# WORKDIR /home
-#
-# RUN apt-get update && \
-#     apt-get install -y --no-install-recommends ${PACKAGES} && \
-#     apt-get clean
-
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a
 ENV PATH /opt/conda/envs/nfcore-kmermaid-0.1dev/bin:$PATH
-#
-#
-# # Required for multiprocessing of 10x bam file - pysam, pathos modules are currently optional installations in sourmash
-# # For computing signatures using sourmash - which kmermaid does, they are required, so we need to install it out of sourmash
-# RUN pip install pathos==0.2.4 pysam==0.15.3
-# RUN which -a pip
-# RUN which -a python
-# RUN cd /home && \
-#     git clone https://github.com/czbiohub/sourmash.git && \
-#     cd sourmash && \
-#     python setup.py install
-#
-# RUN which -a sourmash
 
 RUN sourmash info
 COPY docker/sysctl.conf /etc/sysctl.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,36 +7,36 @@ ARG BUILD_DATE
 LABEL org.label-schema.vcs-ref=$VCS_REF \
 org.label-schema.vcs-url="e.g. https://github.com/nf-core/kmermaid"
 
-WORKDIR /home
-
-ENV PACKAGES zlib1g git g++ make ca-certificates gcc zlib1g-dev libc6-dev procps libbz2-dev libcurl4-openssl-dev libssl-dev
-
-# Sourmash requires last 3 of the above apt packages for installation of htslib in pysam
-
-### don't modify things below here for version updates etc.
-
-WORKDIR /home
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ${PACKAGES} && \
-    apt-get clean
+# WORKDIR /home
+#
+# ENV PACKAGES zlib1g git g++ make ca-certificates gcc zlib1g-dev libc6-dev procps libbz2-dev libcurl4-openssl-dev libssl-dev
+#
+# # Sourmash requires last 3 of the above apt packages for installation of htslib in pysam
+#
+# ### don't modify things below here for version updates etc.
+#
+# WORKDIR /home
+#
+# RUN apt-get update && \
+#     apt-get install -y --no-install-recommends ${PACKAGES} && \
+#     apt-get clean
 
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a
 ENV PATH /opt/conda/envs/nfcore-kmermaid-0.1dev/bin:$PATH
-
-
-# Required for multiprocessing of 10x bam file - pysam, pathos modules are currently optional installations in sourmash
-# For computing signatures using sourmash - which kmermaid does, they are required, so we need to install it out of sourmash
-RUN pip install pathos==0.2.4 pysam==0.15.3
-RUN which -a pip
-RUN which -a python
-RUN cd /home && \
-    git clone https://github.com/czbiohub/sourmash.git && \
-    cd sourmash && \
-    python setup.py install
-
-RUN which -a sourmash
+#
+#
+# # Required for multiprocessing of 10x bam file - pysam, pathos modules are currently optional installations in sourmash
+# # For computing signatures using sourmash - which kmermaid does, they are required, so we need to install it out of sourmash
+# RUN pip install pathos==0.2.4 pysam==0.15.3
+# RUN which -a pip
+# RUN which -a python
+# RUN cd /home && \
+#     git clone https://github.com/czbiohub/sourmash.git && \
+#     cd sourmash && \
+#     python setup.py install
+#
+# RUN which -a sourmash
 
 RUN sourmash info
 COPY docker/sysctl.conf /etc/sysctl.conf

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ test:
 
 docker_push:
 	sudo docker login
-	docker push czbiohub/nf-kmer-similarity:dev
+	docker push nfcore/kmermaid:dev
 
 docker_build:
 	@docker build \
 		--build-arg VCS_REF=`git rev-parse --short HEAD`  \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
-		-t czbiohub/nf-kmer-similarity:dev .
+		-t nfcore/kmermaid:dev .

--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,6 @@ dependencies:
   - alabaster
   - conda-forge::gxx_linux-64
   - pip
+  - fastqc
+  - pip:
+    - git+https://github.com/czbiohub/khtools.git@olgabot/partition-coding-reads

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - alabaster
   - conda-forge::gxx_linux-64
   - pip
+  - fastp=0.20.0
   - fastqc
   - pathos=0.2.4
   - pysam=0.15.3

--- a/environment.yml
+++ b/environment.yml
@@ -17,9 +17,6 @@ dependencies:
   - alabaster
   - conda-forge::gxx_linux-64
   - pip
-  - fastqc
-  - pip:
-    - git+https://github.com/czbiohub/khtools.git@olgabot/partition-coding-reads
   - fastp=0.20.0
   - fastqc
   - pathos=0.2.4

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,9 @@ dependencies:
   - alabaster
   - conda-forge::gxx_linux-64
   - pip
+  - fastqc
+  - pip:
+    - git+https://github.com/czbiohub/khtools.git@olgabot/partition-coding-reads
   - fastp=0.20.0
   - fastqc
   - pathos=0.2.4

--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,9 @@ dependencies:
   - conda-forge::gxx_linux-64
   - pip
   - fastqc
+  - pathos=0.2.4
+  - pysam=0.15.3
+  - multiqc
   - pip:
-    - git+https://github.com/czbiohub/khtools.git@olgabot/partition-coding-reads
+    - git+https://github.com/czbiohub/kh-tools.git@olgabot/partition-coding-reads#egg=khtools
+    - git+https://github.com/czbiohub/sourmash.git@master#egg=sourmash


### PR DESCRIPTION
To enable the `-profile conda` profile, this PR moves all installation into environment.yml and adds fastqc and khtools to the requirements

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/kmer-similarity/tree/master/.github/CONTRIBUTING.md
