### PR TITLE
remove redundant bam2fasta installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Update Dockerfile with sourmash compute bam input dependencies
 * Add `track_abundance` feature to keep track of hashed kmer frequency.
 * Add [czbiohub/khtools](https://github.com/czbiohub/kh-tools/) repo to environment.yml
-* Add [`bam2fasta`](https://pypi.org/project/bam2fasta/) to environment.yml
+* Add [`czbiohub/bam2fasta`](https://github.com/czbiohub/bam2fasta/) repo to environment.yml
 
 
 ## v0.1.0 - 6 March 2019

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - bioconda::bam2fasta=1.0.1
   - bioconda::khmer=3.0.0a3
   - bioconda::bioconductor-edger=3.28.0
   - conda-forge::gxx_linux-64=7.3.0


### PR DESCRIPTION
bam2fasta installation through git available in the pip dependencies section, also the save-intermediate-files flag needs the update install not the 1.0.1 version.

Many thanks to contributing to nf-core/kmer-similarity!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/kmer-similarity branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/kmer-similarity)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/kmer-similarity/tree/master/.github/CONTRIBUTING.md
