### PR TITLE
Update sourmash version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Add `track_abundance` feature to keep track of hashed kmer frequency.
 * Add [czbiohub/khtools](https://github.com/czbiohub/kh-tools/) repo to environment.yml
 * Add [`czbiohub/bam2fasta`](https://github.com/czbiohub/bam2fasta/) repo to environment.yml
+* Update sourmash to version 3.2.2
 
 ## v0.1.0 - 6 March 2019
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - conda-forge::r-gplots=3.0.1.1
   - bioconda::bioconductor-edger=3.28.0
   - conda-forge::r-markdown=1.1
-  - bioconda::sourmash=2.0.1
+  - bioconda::sourmash=3.2.2
   - bioconda::samtools=1.10
   - conda-forge::gxx_linux-64
   - bioconda::screed=1.0.4


### PR DESCRIPTION
Update sourmash version to avoid [this error](https://travis-ci.com/github/nf-core/kmermaid/jobs/319839197):

```pytb
executor >  local (710)
[77/67e4ad] process > get_software_versions          [100%] 1 of 1 ✔
[f5/8ba6cb] process > tenx_tgz_extract_bam           [100%] 2 of 2 ✔
[a8/ba802c] process > samtools_fastq_aligned         [100%] 2 of 2 ✔
[9a/01375b] process > samtools_fastq_unaligned       [100%] 2 of 2 ✔
[7d/a16253] process > count_umis_per_cell            [100%] 2 of 2 ✔
[d8/bfbe7f] process > extract_per_cell_fastqs        [100%] 3 of 3 ✔
[6a/5eb2f2] process > fastp                          [100%] 276 of 276 ✔
[29/5f384e] process > sourmash_compute_sketch_fas... [ 38%] 421 of 1103, fail...
[-        ] process > sourmash_compare_sketches      [  0%] 0 of 2
[0;35m[nf-core/kmermaid] Pipeline completed with errors
WARN: Killing pending tasks (1)
WARN: To render the execution DAG in the required format it is required to install Graphviz -- See http://www.graphviz.org for more info.
Error executing process > 'sourmash_compute_sketch_fastx_nucleotide (mouse_brown_fat_ptprc_plus_unaligned__aligned__CCATGTCCAAGCGATG_molecule-dna_ksize-3_log2sketchsize-2_trackabundance-false)'
Caused by:
  Process `sourmash_compute_sketch_fastx_nucleotide (mouse_brown_fat_ptprc_plus_unaligned__aligned__CCATGTCCAAGCGATG_molecule-dna_ksize-3_log2sketchsize-2_trackabundance-false)` terminated with an error exit status (1)
Command executed:
  sourmash compute \
    --num-hashes $((2**2)) \
    --ksizes 3 \
    --dna \
     \
    --output mouse_brown_fat_ptprc_plus_unaligned__aligned__CCATGTCCAAGCGATG_molecule-dna_ksize-3_log2sketchsize-2_trackabundance-false.sig \
    mouse_brown_fat_ptprc_plus_unaligned__aligned__CCATGTCCAAGCGATG_R1_trimmed.fastq.gz
Command exit status:
  1
Command output:
  (empty)
Command error:
  
  
  == This is sourmash version 2.0.0a10.dev121+ged5be32. ==
  
  == Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==
  
  
  computing signatures for files: mouse_brown_fat_ptprc_plus_unaligned__aligned__CCATGTCCAAGCGATG_R1_trimmed.fastq.gz
  
  Computing signature for ksizes: [3]
  
  Computing only nucleotide (and not protein) signatures.
  
  Computing a total of 1 signature(s).
  
  ... reading sequences from mouse_brown_fat_ptprc_plus_unaligned__aligned__CCATGTCCAAGCGATG_R1_trimmed.fastq.gz
  Traceback (most recent call last):
    File "/opt/conda/envs/nf-core-kmermaid-1.0.0dev/bin/sourmash", line 8, in <module>
      sys.exit(main())
    File "/opt/conda/envs/nf-core-kmermaid-1.0.0dev/lib/python3.7/site-packages/sourmash/__main__.py", line 14, in main
      return mainmethod(args)
    File "/opt/conda/envs/nf-core-kmermaid-1.0.0dev/lib/python3.7/site-packages/sourmash/cli/compute.py", line 141, in main
      return compute(args)
    File "/opt/conda/envs/nf-core-kmermaid-1.0.0dev/lib/python3.7/site-packages/sourmash/command_compute.py", line 210, in compute
      notify('...{} {} sequences', filename, n, end='')
  UnboundLocalError: local variable 'n' referenced before assignment
```

## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] `CHANGELOG.md` is updated

