### PR TITLE
[MRG] check for file size 0 

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -670,8 +670,10 @@ if (params.tenx_tgz || params.bam) {
     script:
     is_aligned_channel_id = "${channel_id}__${is_aligned}__"
     def rename_10x_barcodes = params.rename_10x_barcodes ? "--rename-10x-barcodes ${rename_10x_barcodes.baseName}.tsv": ''
+    processes = "--processes ${task.cpus}"
     """
     bam2fasta make_fastqs_percell \\
+        $processes \\
         --filename ${reads} \\
         --barcodes-significant-umis-fil ${barcodes} \\
         $rename_10x_barcodes \\
@@ -924,7 +926,7 @@ process sourmash_compute_sketch_fastx_nucleotide {
     }
   }
   sourmash_sketches_nucleotide = sourmash_sketches_all_nucleotide.filter{ it[4].size() > 0 }
-  
+
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -891,6 +891,9 @@ process sourmash_compute_sketch_fastx_nucleotide {
   processes = "--processes ${task.cpus}"
   if ( params.one_signature_per_record){
       """
+      # Check if the fastq.gz file is empty
+      # Find the uncompressed file size in the 2nd column listed
+      # by gzip -l and run sourmash compute only if it is nonzero
       if [ `gzip -l \$(realpath $reads) | awk 'NR==2 {print \$2}'` -ne 0 ]; then
         sourmash compute \\
           --num-hashes \$((2**$log2_sketch_size)) \\
@@ -901,13 +904,16 @@ process sourmash_compute_sketch_fastx_nucleotide {
           --output ${sample_id}_${sketch_id}.sig \\
           $reads
       fi
-      # Decoy file just in case there are no reads found,
+      # Decoy file just in case there are no sigs found,
       # to prevent this process from erroring out
       touch ${sample_id}_${sketch_id}.sig
       """
   }
   else {
     """
+      # Check if the fastq.gz file is empty
+      # Find the uncompressed file size in the 2nd column listed
+      # by gzip -l and run sourmash compute only if it is nonzero
       if [ `gzip -l \$(realpath $reads) | awk 'NR==2 {print \$2}'` -ne 0 ]; then
         sourmash compute \\
         --num-hashes \$((2**$log2_sketch_size)) \\
@@ -919,7 +925,7 @@ process sourmash_compute_sketch_fastx_nucleotide {
         --merge '$sample_id' \\
         $reads
       fi
-      # Decoy file just in case there are no reads found,
+      # Decoy file just in case there are no sigs found,
       # to prevent this process from erroring out
       touch ${sample_id}_${sketch_id}.sig
     """
@@ -953,6 +959,9 @@ if (params.peptide_fasta){
     processes = "--processes ${task.cpus}"
     if ( params.one_signature_per_record) {
       """
+      # Check if the fastq.gz file is empty
+      # Find the uncompressed file size in the 2nd column listed
+      # by gzip -l and run sourmash compute only if it is nonzero
       if [ `gzip -l \$(realpath $reads) | awk 'NR==2 {print \$2}'` -ne 0 ]; then
         sourmash compute \\
           --num-hashes \$((2**$log2_sketch_size)) \\
@@ -965,13 +974,16 @@ if (params.peptide_fasta){
           --output ${sample_id}_${sketch_id}.sig \\
           $reads
       fi
-      # Decoy file just in case there are no reads found,
+      # Decoy file just in case there are no sigs found,
       # to prevent this process from erroring out
       touch ${sample_id}_${sketch_id}.sig
       """
     }
     else {
       """
+      # Check if the fastq.gz file is empty
+      # Find the uncompressed file size in the 2nd column listed
+      # by gzip -l and run sourmash compute only if it is nonzero
         if [ `gzip -l \$(realpath $reads) | awk 'NR==2 {print \$2}'` -ne 0 ]; then
           sourmash compute \\
             --num-hashes \$((2**$log2_sketch_size)) \\
@@ -985,7 +997,7 @@ if (params.peptide_fasta){
             --merge '$sample_id' \\
             $reads
         fi
-      # Decoy file just in case there are no reads found,
+      # Decoy file just in case there are no sigs found,
       # to prevent this process from erroring out
       touch ${sample_id}_${sketch_id}.sig
       """


### PR DESCRIPTION
1. adding processes flag to make_fastqs_per_cell and other sourmash compute that actually enables parallelization which was missing before
2. use barcodes_file if provides and rename_10x_barcodes
3. check the uncompressed gzip file is 0 bytes instead of filtering the compressed file for an arbitrary size of 20 bytes assuming the header is that size. It can vary and be different on different operating systems.

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/kmer-similarity branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/kmer-similarity)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/kmer-similarity/tree/master/.github/CONTRIBUTING.md
