### PR TITLE
Output ALL aligned reads from samtools_fastq_aligned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Add samtools_fastq_unaligned and samtools_fastq_aligned process for converting bam to per cell
 barcode fastq
 * Remove `one_signature_per_record` flag and add bam2fasta count_umis_percell and make_fastqs_percell instead of bam2fasta sharding method
+* Make sure `samtools_fastq_aligned` outputs ALL aligned reads, regardless of mapping quality or primary alignment status
 
 ### Dependency updates
 

--- a/main.nf
+++ b/main.nf
@@ -555,7 +555,7 @@ if (params.tenx_tgz || params.bam) {
     script:
     reads = "${channel_id}__aligned.fastq.gz"
     """
-    samtools view -ub -F 256 -q 255 ${bam} \\
+    samtools view -ub -F 4 ${bam} \\
         | samtools fastq --threads ${task.cpus} -T ${tenx_tags} - \\
         | gzip -c - \\
           > ${reads}


### PR DESCRIPTION
`samtools view -ub -F 4 ` will output ALL aligned reads, regardless of primary/supplementary alignments, while the current

```
samtools view -ub -f 256 -q 255
```

Will only output primary alignment reads, and only high quality alignments. I want the pipeline to output all aligned reads, regardless of quality. Here are some screenshots from https://broadinstitute.github.io/picard/explain-flags.html:

![Screen Shot 2020-04-28 at 8 48 07 AM](https://user-images.githubusercontent.com/806256/80508824-5fae1800-892d-11ea-9b27-93e2eaa09eda.png)
![Screen Shot 2020-04-28 at 8 48 01 AM](https://user-images.githubusercontent.com/806256/80508828-60df4500-892d-11ea-8a8f-e729d5383961.png)


## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [x] `CHANGELOG.md` is updated

