### PR TITLE
Re-add --protein_fastas option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
     jdk: openjdk8
   - name: "Latest Nextflow version, regular test suite"
     env: NXF_VER='' SUITE=test FLAGS=
+  - name: "Test nextflow kmermaid, with --skip_trimming"
+    env: NXF_VER='' SUITE=test FLAGS='--skip_trimming'
   - name: "Test nextflow kmermaid, with --track_abundance"
     env: NXF_VER='' SUITE=test FLAGS='--track_abundance'
   - name: "Test nextflow kmermaid, with translate on fastas"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
     env: NXF_VER='' SUITE=test FLAGS='--skip_trimming'
   - name: "Test nextflow kmermaid, with --track_abundance"
     env: NXF_VER='' SUITE=test FLAGS='--track_abundance'
+  - name: "Test fasta input"
+    env: NXF_VER='' SUITE=test_fastas FLAGS=
   - name: "Test nextflow kmermaid, with translate on fastas"
     env: NXF_VER='' SUITE=test_translate
   - name: "Latest Nextflow version, regular test suite with splitKmers, ensure that `protein` can't be specified"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --splitKmer ; if [ $? -eq 0 ]; then echo "--splitKmer + --molecules protein should fail but did not" && exit 1 ; else echo "Correctly failed --splitKmer + --molecules protein" ; fi
   - name: "Latest Nextflow version, split k-mer test suite"
     env: NXF_VER='' SUITE=test_ska FLAGS=
-  - name: "Latest Nextflow version, split k-mer test suite"
+  - name: "Latest Nextflow version, split k-mer test suite, with --skip_trimming"
     env: NXF_VER='' SUITE=test_ska FLAGS=--skip_trimming
   - name: "Latest Nextflow version, split k-mer test suite, test subsampling"
     env: NXF_VER='' SUITE=test_ska FLAGS='--subsample 10'
@@ -33,7 +33,7 @@ matrix:
   #   script: markdownlint ${TRAVIS_BUILD_DIR} -c ${TRAVIS_BUILD_DIR}/.github/markdownlint.yml
   - name: "Test nextflow kmermaid, with 10x .tgz file"
     env: NXF_VER='' SUITE=test_tenx_tgz FLAGS=
-  - name: "Test nextflow kmermaid, with 10x .tgz file"
+  - name: "Test nextflow kmermaid, with 10x .tgz file, with --skip_trimming"
     env: NXF_VER='' SUITE=test_tenx_tgz FLAGS=--skip_trimming
   - name: "Test nextflow kmermaid, with 10x .tgz file and min 2 UMI per cell"
     env: NXF_VER='' SUITE=test_tenx_tgz FLAGS='--tenx_min_umi_per_cell 2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ barcode fastq
 * Remove `one_signature_per_record` flag and add bam2fasta count_umis_percell and make_fastqs_percell instead of bam2fasta sharding method
 * Update renaming of `khtools` commands to `sencha`
 * Make sure `samtools_fastq_aligned` outputs ALL aligned reads, regardless of mapping quality or primary alignment status
+* Add `--protein_fastas` option for translated protein input
 
 ### Dependency updates
 

--- a/conf/test_fastas.config
+++ b/conf/test_fastas.config
@@ -1,0 +1,30 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/kmermaid -profile test
+ */
+
+params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on Travis
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+  // Input data
+  // samples = 'testing/samples.csv'
+  // fastas = 'testing/fastas/*.fasta'
+  ksizes = '3,9'
+  log2_sketch_sizes = '2,4'
+  molecules = 'dna,protein,dayhoff'
+  // read_pairs = 'testing/fastqs/*{1,2}.fastq.gz'
+  // sra = "SRP016501"
+  fasta_paths = [
+    ['SRR4050379', ['https://github.com/nf-core/test-datasets/raw/olgabot/kmermaid--bam-unique-names/testdata/SRR4050379_pass_concatenated.fasta']],
+    ['SRR4050380', ['https://github.com/nf-core/test-datasets/raw/olgabot/kmermaid--bam-unique-names/testdata/SRR4050380_pass_concatenated.fasta']],
+
+  ]
+}

--- a/conf/test_protein_fastas.config
+++ b/conf/test_protein_fastas.config
@@ -1,0 +1,34 @@
+/*
+ * -------------------------------------------------------------------
+ *  Nextflow config file for running tests with bam, extract_coding
+ * -------------------------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/kmermaid -profile test_extract_coding.config
+ */
+
+params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on Travis
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+  // Input data
+  protein_fasta_paths = [
+  ["10x_mouse_lung_ptprc",
+    ['https://github.com/czbiohub/test-datasets/raw/predictorthologs/testdata/10x_mouse_lung_ptprc__molecule-dayhoff__coding_reads_peptides.fasta']],
+  ["human_liver_ptprc",
+      ['https://github.com/czbiohub/test-datasets/raw/predictorthologs/testdata/human_liver_ptprc__molecule-dayhoff__coding_reads_peptides.fasta']],
+  ["orangutan_brain_ptprc",
+      ['https://github.com/czbiohub/test-datasets/raw/predictorthologs/testdata/orangutan_brain_ptprc__molecule-dayhoff__coding_reads_peptides.fasta']],
+  ["bonobo_liver_ptprc",
+      ['https://github.com/czbiohub/test-datasets/raw/predictorthologs/testdata/bonobo_liver_ptprc__molecule-dayhoff__coding_reads_peptides.fasta']]]
+
+  // Sketch Parameters
+  ksizes = '9,15'
+  log2_sketch_sizes = '2,4'
+  molecules = 'protein,dayhoff,hp'
+  read_pairs = false
+
+}

--- a/conf/test_translate.config
+++ b/conf/test_translate.config
@@ -22,8 +22,7 @@ params {
   molecules = 'dna,protein,dayhoff'
   read_pairs = false
 
-
-  peptide_fasta = 'https://github.com/nf-core/test-datasets/raw/kmermaid/reference/gencode.v32.pc_translations.subsample5.randomseed0.fa'
+  reference_proteome_fasta = 'https://github.com/nf-core/test-datasets/raw/kmermaid/reference/gencode.v32.pc_translations.subsample5.randomseed0.fa'
   bloomfilter_tablesize = '1e8'
   extract_coding_peptide_ksize = '11'
   extract_coding_peptide_molecule = 'dayhoff'

--- a/conf/test_translate.config
+++ b/conf/test_translate.config
@@ -1,10 +1,10 @@
 /*
  * -------------------------------------------------------------------
- *  Nextflow config file for running tests with bam, extract_coding
+ *  Nextflow config file for running tests with bam, translate
  * -------------------------------------------------------------------
  * Defines bundled input files and everything required
  * to run a fast and simple test. Use as follows:
- *   nextflow run nf-core/kmermaid -profile test_extract_coding.config
+ *   nextflow run nf-core/kmermaid -profile test_translate.config
  */
 
 params {
@@ -24,6 +24,6 @@ params {
 
   reference_proteome_fasta = 'https://github.com/nf-core/test-datasets/raw/kmermaid/reference/gencode.v32.pc_translations.subsample5.randomseed0.fa'
   bloomfilter_tablesize = '1e8'
-  extract_coding_peptide_ksize = '11'
-  extract_coding_peptide_molecule = 'dayhoff'
+  translate_peptide_ksize = '11'
+  translate_peptide_molecule = 'dayhoff'
 }

--- a/conf/test_translate_bam.config
+++ b/conf/test_translate_bam.config
@@ -29,7 +29,7 @@ params {
   tenx_min_umi_per_cell = 10
   shard_size = 350
 
-  peptide_fasta = 'https://github.com/nf-core/test-datasets/raw/kmermaid/reference/ptprc_bam_translations.fa'
+  reference_proteome_fasta = 'https://github.com/nf-core/test-datasets/raw/kmermaid/reference/ptprc_bam_translations.fa'
   bloomfilter_tablesize = '1e8'
   translate_peptide_ksize = '11'
   translate_peptide_molecule = 'dayhoff'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,6 +18,7 @@
         * [`--csv_pairs`](#--csv_pairs)
         * [`--csv_singles`](#--csv_singles)
         * [`--fastas`](#--fastas)
+        * [`--protein_fastas`](#--protein_fastas)
         * [`--sra`](#--sra)
         * [`--bam`](#--bam)
         * [`--barcodes_file`](#--barcodes_file)
@@ -205,6 +206,23 @@ Please note the following requirements:
 2. The path *may* have at one or more `*` wildcard character
 
 If left unspecified, no samples are used.
+
+
+### `--protein_fastas`
+
+Use this to specify the location of *protein* fasta sequence files. No trimming, subsampling, or protein translation is done on these. Multiple inputs can be separated by seimcolons (`;`). For example:
+
+```bash
+--protein_fastas 'path/to/data/elephant.fasta;more/data/*.fasta'
+```
+
+Please note the following requirements:
+
+1. The path must be enclosed in quotes
+2. The path *may* have at one or more `*` wildcard character
+
+If left unspecified, no samples are used.
+
 
 ### `--sra`
 

--- a/main.nf
+++ b/main.nf
@@ -260,7 +260,7 @@ if (params.read_paths) {
 /* --          Parse protein fastas            -- */
 ////////////////////////////////////////////////////
 if (params.protein_fastas){
-  Channel.fromPath(params.protein_fastas?.toString()?.tokenize(';'), checkIfExists: true)
+  Channel.fromPath(params.protein_fastas?.toString()?.tokenize(';'), checkIfExists: true, size: 1)
       .map{ f -> tuple(f.baseName, tuple(file(f))) }
       .ifEmpty { exit 1, "params.protein_fastas was empty - no input files supplied" }
       .set { ch_protein_fastas }

--- a/main.nf
+++ b/main.nf
@@ -260,7 +260,7 @@ if (params.read_paths) {
 /* --          Parse protein fastas            -- */
 ////////////////////////////////////////////////////
 if (params.protein_fastas){
-  Channel.fromPath(params.protein_fastas?.toString()?.tokenize(';'), checkIfExists: true, size: 1)
+  Channel.fromFilePairs(params.protein_fastas?.toString()?.tokenize(';'), checkIfExists: true, size: 1)
       .map{ f -> tuple(f.baseName, tuple(file(f))) }
       .ifEmpty { exit 1, "params.protein_fastas was empty - no input files supplied" }
       .set { ch_protein_fastas }

--- a/main.nf
+++ b/main.nf
@@ -756,8 +756,11 @@ if (params.tenx_tgz || params.bam) {
   }
 }
 
-
-n_files_to_trim = ch_read_files_trimming_to_check_size.toList().value.size()
+if (ch_read_files_trimming_to_check_size.toList().value) {
+  n_files_to_trim = ch_read_files_trimming_to_check_size.toList().value.size()  
+} else {
+  n_files_to_trim = 0
+}
 do_nucleotide_stuff = n_files_to_trim || params.reference_proteome_fasta || params.subsample
 
 if ( do_nucleotide_stuff ) {

--- a/main.nf
+++ b/main.nf
@@ -348,7 +348,7 @@ if (!protein_input) {
       .set { reads_ch }
   } else {
     ch_read_files_trimming_unchecked
-      .ifEmpty{ exit 1, "No reads provided! Check read input files"}
+      .ifEmpty{ exit 1, "No reads provided! Check read input files in ch_read_files_trimming_unchecked"}
       .into { ch_read_files_trimming_to_trim; ch_read_files_trimming_to_check_size }
   }
   if (params.bam) {

--- a/main.nf
+++ b/main.nf
@@ -171,11 +171,10 @@ fastas_ch = Channel.empty()
 tenx_tgz_ch = Channel.empty()
 
 // Boolean for if an nucleotide input
-have_nucleotide_input = false
+have_nucleotide_input = params.read_paths || params.sra || params.csv_pairs || params.csv_singles || params.read_pairs || params.read_singles || params.fastas || params.bam || params.tenx_tgz
 
 // Parameters for testing
 if (params.read_paths) {
-  have_nucleotide_input = true
      read_paths_ch = Channel
         .from(params.read_paths)
         .map { row -> if (row[1].size() == 2) [ row[0], [file(row[1][0]), file(row[1][1])]]
@@ -184,14 +183,12 @@ if (params.read_paths) {
  } else {
    // Provided SRA ids
    if (params.sra){
-     have_nucleotide_input = true
      sra_ch = Channel
          .fromSRA( params.sra?.toString()?.tokenize(';') )
          .ifEmpty { exit 1, "params.sra ${params.sra} was not found - no input files supplied" }
    }
    // Provided a samples.csv file of read pairs
    if (params.csv_pairs){
-     have_nucleotide_input = true
      csv_pairs_ch = Channel
       .fromPath(params.csv_pairs)
       .splitCsv(header:true)
@@ -201,7 +198,6 @@ if (params.read_paths) {
 
    // Provided a samples.csv file of single-ended reads
    if (params.csv_singles){
-     have_nucleotide_input = true
      csv_singles_ch = Channel
       .fromPath(params.csv_singles)
       .splitCsv(header:true)
@@ -211,21 +207,18 @@ if (params.read_paths) {
 
    // Provided fastq gz paired-end reads
    if (params.read_pairs){
-     have_nucleotide_input = true
      read_pairs_ch = Channel
        .fromFilePairs(params.read_pairs?.toString()?.tokenize(';'), size: 2)
        .ifEmpty { exit 1, "params.read_pairs (${params.read_pairs}) was empty - no input files supplied" }
    }
    // Provided fastq gz single-end reads
    if (params.read_singles){
-     have_nucleotide_input = true
      read_singles_ch = Channel
        .fromFilePairs(params.read_singles?.toString()?.tokenize(';'), size: 1)
        .ifEmpty { exit 1, "params.read_singles (${params.read_singles}) was empty - no input files supplied" }
   }
    // Provided vanilla fastas
    if (params.fastas){
-     have_nucleotide_input = true
      fastas_ch = Channel
        .fromPath(params.fastas?.toString()?.tokenize(';'))
        .map{ f -> tuple(f.baseName, tuple(file(f))) }
@@ -233,7 +226,6 @@ if (params.read_paths) {
    }
 
   if (params.bam) {
-    have_nucleotide_input = true
   Channel.fromPath(params.bam, checkIfExists: true)
         .map{ f -> tuple(f.baseName, tuple(file(f))) }
        .ifEmpty { exit 1, "Bam file not found: ${params.bam}" }

--- a/main.nf
+++ b/main.nf
@@ -260,7 +260,7 @@ if (params.read_paths) {
 /* --          Parse protein fastas            -- */
 ////////////////////////////////////////////////////
 if (params.protein_fastas){
-  Channel.fromPath(params.protein_fastas)
+  Channel.fromPath(params.protein_fastas?.toString()?.tokenize(';'), checkIfExists: true)
       .ifEmpty { exit 1, "params.protein_fastas was empty - no input files supplied" }
       .set { ch_protein_fastas }
 } else if (params.protein_fasta_paths){

--- a/main.nf
+++ b/main.nf
@@ -783,11 +783,12 @@ if (!params.skip_trimming && files_to_trim) {
 } else {
   n_files_to_trim = 0
 }
+println "n_files_to_trim: ${n_files_to_trim}"
 
-do_nucleotide_stuff = n_files_to_trim || params.reference_proteome_fasta || params.subsample || have_nucleotide_input
+do_nucleotide_stuff = params.reference_proteome_fasta || params.subsample || have_nucleotide_input
 
 if ( do_nucleotide_stuff ) {
-  if (!params.skip_trimming && n_files_to_trim > 0){
+  if (!params.skip_trimming){
     process fastp {
         label 'process_low'
         tag "$name"

--- a/main.nf
+++ b/main.nf
@@ -363,16 +363,16 @@ if (!protein_input) {
       .ifEmpty{ exit 1, "No reads provided! Check read input files" }
       .set { reads_ch }
     ch_read_files_trimming_to_check_size = Channel.empty()
+  } else if (params.bam || params.tenx_tgz) {
+    ch_non_bam_reads_unchecked
+      // No need to check if empty since there is bam input
+      .set { ch_non_bam_reads }
   } else {
     ch_read_files_trimming_unchecked
       .ifEmpty{ exit 1, "No reads provided! Check read input files" }
       .into { ch_read_files_trimming_to_trim; ch_read_files_trimming_to_check_size }
   }
-  if (params.bam) {
-    ch_non_bam_reads_unchecked
-     .ifEmpty{ exit 1, "No reads provided! Check read input files" }
-      .set { ch_non_bam_reads }
-  }
+
 } else {
   // Since there exists protein input, don't check if these are empty
   if (params.subsample) {
@@ -770,7 +770,8 @@ if (params.tenx_tgz || params.bam) {
     ch_read_files_trimming_to_check_size = Channel.empty()
   } else {
     ch_non_bam_reads
-      .concat(per_cell_fastqs_ch)
+      .mix ( per_cell_fastqs_ch )
+      .dump ( tag: 'ch_non_bam_reads__per_cell_fastqs_ch' )
       .into{ ch_read_files_trimming_to_trim; ch_read_files_trimming_to_check_size }
   }
 }

--- a/main.nf
+++ b/main.nf
@@ -915,7 +915,7 @@ if ( have_nucleotide_input ) {
  */
 if (!params.remove_ribo_rna) {
     ch_reads_for_ribosomal_removal
-        .into { reads_ch }
+        .set { reads_ch }
     sortmerna_logs = Channel.empty()
 } else {
     process sortmerna_index {

--- a/main.nf
+++ b/main.nf
@@ -338,10 +338,9 @@ if (params.subsample) {
       }
     }
   } else {
-//   Do nothing - can't combine the fastq files and bam files (yet)
       sra_ch.concat(
           csv_pairs_ch, csv_singles_ch, read_pairs_ch,
-          read_singles_ch, read_paths_ch, fastas_ch)
+          read_singles_ch, read_paths_ch)
         .dump ( tag: 'ch_non_bam_reads_unchecked__concatenated' )
         .set{ ch_non_bam_reads_unchecked }
     }

--- a/main.nf
+++ b/main.nf
@@ -349,7 +349,7 @@ if (params.subsample) {
 
 protein_input = params.protein_fastas || params.protein_fasta_paths
 if (!protein_input) {
-  if (params.subsample) {
+  if (params.subsample && params.skip_trimming ) {
     subsample_reads_ch_unchecked
       .ifEmpty{  exit 1, "No reads provided! Check read input files" }
       .set { subsample_reads_ch }

--- a/main.nf
+++ b/main.nf
@@ -455,6 +455,7 @@ if(params.csv_pairs)    summary['Paired-end samples.csv']            = params.cs
 if(params.csv_singles)  summary['Single-end samples.csv']    = params.csv_singles
 if(params.sra)          summary['SRA']                             = params.sra
 if(params.fastas)       summary["FASTAs"]                          = params.fastas
+if(params.protein_fastas) summary["Protein FASTAs"]                = params.protein_fastas
 if(params.bam)          summary["BAM"]                             = params.bam
 if(params.barcodes_file)          summary["Barcodes"]              = params.barcodes_file
 if(params.rename_10x_barcodes)    summary["Renamer barcodes"]      = params.rename_10x_barcodes
@@ -756,8 +757,8 @@ if (params.tenx_tgz || params.bam) {
   }
 }
 
-if (ch_read_files_trimming_to_check_size.toList().value) {
-  n_files_to_trim = ch_read_files_trimming_to_check_size.toList().value.size()  
+if (!params.skip_trimming) {
+  n_files_to_trim = ch_read_files_trimming_to_check_size.toList().value.size()
 } else {
   n_files_to_trim = 0
 }

--- a/main.nf
+++ b/main.nf
@@ -353,7 +353,7 @@ if (!protein_input) {
   }
   if (params.bam) {
     ch_non_bam_reads_unchecked
-      .ifEmpty{ exit 1, "No reads provided! Check read input files"}
+     .ifEmpty{ exit 1, "No reads provided! Check read input files in ch_non_bam_reads_unchecked")
       .set { ch_non_bam_reads }
   }
 } else {

--- a/main.nf
+++ b/main.nf
@@ -760,8 +760,10 @@ if (params.tenx_tgz || params.bam) {
   }
 }
 
-if (!params.skip_trimming) {
-  n_files_to_trim = ch_read_files_trimming_to_check_size.toList().value.size()
+files_to_trim = ch_read_files_trimming_to_check_size.toList().value
+
+if (!params.skip_trimming && files_to_trim) {
+  n_files_to_trim = files_to_trim.size()
 } else {
   n_files_to_trim = 0
 }

--- a/main.nf
+++ b/main.nf
@@ -962,6 +962,7 @@ if ( do_nucleotide_stuff ) {
         --num-hashes \$((2**$log2_sketch_size)) \\
         --ksizes $ksize \\
         --dna \\
+        --name ${sample_id} \\
         $processes \\
         $track_abundance_flag \\
         --output ${sample_id}_${sketch_id}.sig \\
@@ -1005,6 +1006,7 @@ if (protein_input || params.reference_proteome_fasta){
         --ksizes $ksize \\
         --input-is-protein \\
         --$molecule \\
+        --name ${sample_id} \\
         --no-dna \\
         $processes \\
         $track_abundance_flag \\

--- a/main.nf
+++ b/main.nf
@@ -260,7 +260,7 @@ if (params.read_paths) {
 /* --          Parse protein fastas            -- */
 ////////////////////////////////////////////////////
 if (params.protein_fastas){
-  Channel.fromFilePairs(params.protein_fastas?.toString()?.tokenize(';'), checkIfExists: true, size: 1)
+  Channel.fromPath(params.protein_fastas?.toString()?.tokenize(';'))
       .map{ f -> tuple(f.baseName, tuple(file(f))) }
       .ifEmpty { exit 1, "params.protein_fastas was empty - no input files supplied" }
       .set { ch_protein_fastas }

--- a/main.nf
+++ b/main.nf
@@ -261,6 +261,7 @@ if (params.read_paths) {
 ////////////////////////////////////////////////////
 if (params.protein_fastas){
   Channel.fromPath(params.protein_fastas?.toString()?.tokenize(';'), checkIfExists: true)
+      .map{ f -> tuple(f.baseName, tuple(file(f))) }
       .ifEmpty { exit 1, "params.protein_fastas was empty - no input files supplied" }
       .set { ch_protein_fastas }
 } else if (params.protein_fasta_paths){

--- a/main.nf
+++ b/main.nf
@@ -172,7 +172,6 @@ tenx_tgz_ch = Channel.empty()
 
 // Boolean for if an nucleotide input exists anywhere
 have_nucleotide_input = params.read_paths || params.sra || params.csv_pairs || params.csv_singles || params.read_pairs || params.read_singles || params.fastas || params.bam || params.tenx_tgz
-println "have_nucleotide_input: ${have_nucleotide_input}"
 
 // Parameters for testing
 if (params.read_paths) {
@@ -315,7 +314,6 @@ if (params.subsample) {
     }
   }
 } else {
-  println 'No subsample'
   if (!(params.tenx_tgz || params.bam)) {
     if(params.skip_trimming){
       sra_ch.concat(
@@ -774,16 +772,6 @@ if (params.tenx_tgz || params.bam) {
   }
 }
 
-files_to_trim = ch_read_files_trimming_to_check_size.toList().value
-
-if (!params.skip_trimming && files_to_trim) {
-  n_files_to_trim = files_to_trim.size()
-} else {
-  n_files_to_trim = 0
-}
-println "n_files_to_trim: ${n_files_to_trim}"
-
-do_nucleotide_stuff = params.reference_proteome_fasta || params.subsample || have_nucleotide_input
 
 if ( have_nucleotide_input ) {
   if (!params.skip_trimming){

--- a/main.nf
+++ b/main.nf
@@ -344,7 +344,7 @@ if (!protein_input) {
   }
   if (params.skip_trimming) {
     reads_ch_unchecked
-      .ifEmpty{ exit 1, "No reads provided! Check read input files"}
+      .ifEmpty{ exit 1, "No reads provided! Check read input files in reads_ch_unchecked"}
       .set { reads_ch }
   } else {
     ch_read_files_trimming_unchecked

--- a/main.nf
+++ b/main.nf
@@ -339,7 +339,7 @@ if (!protein_input) {
   println "in not protein input"
   if (params.subsample) {
     subsample_reads_ch_unchecked
-      .ifEmpty{ exit 1, "No reads provided! Check read input files"}
+      .ifEmpty{  exit 1, "No reads provided! Check read input files in subsample_reads_ch_unchecked"}
       .set { subsample_reads_ch }
   }
   if (params.skip_trimming) {

--- a/main.nf
+++ b/main.nf
@@ -343,21 +343,21 @@ protein_input = params.protein_fastas || params.protein_fasta_paths
 if (!protein_input) {
   if (params.subsample) {
     subsample_reads_ch_unchecked
-      .ifEmpty{  exit 1, "No reads provided! Check read input files in subsample_reads_ch_unchecked"}
+      .ifEmpty{  exit 1, "No reads provided! Check read input files" }
       .set { subsample_reads_ch }
   }
   if (params.skip_trimming) {
     reads_ch_unchecked
-      .ifEmpty{ exit 1, "No reads provided! Check read input files in reads_ch_unchecked"}
+      .ifEmpty{ exit 1, "No reads provided! Check read input files" }
       .set { reads_ch }
   } else {
     ch_read_files_trimming_unchecked
-      .ifEmpty{ exit 1, "No reads provided! Check read input files in ch_read_files_trimming_unchecked"}
+      .ifEmpty{ exit 1, "No reads provided! Check read input files" }
       .into { ch_read_files_trimming_to_trim; ch_read_files_trimming_to_check_size }
   }
   if (params.bam) {
     ch_non_bam_reads_unchecked
-     .ifEmpty{ exit 1, "No reads provided! Check read input files in ch_non_bam_reads_unchecked")
+     .ifEmpty{ exit 1, "No reads provided! Check read input files" }
       .set { ch_non_bam_reads }
   }
 } else {

--- a/main.nf
+++ b/main.nf
@@ -170,7 +170,7 @@ fastas_ch = Channel.empty()
 // 10X Genomics .tgz file containing possorted_genome_bam file
 tenx_tgz_ch = Channel.empty()
 
-// Boolean for if an nucleotide input
+// Boolean for if an nucleotide input exists anywhere
 have_nucleotide_input = params.read_paths || params.sra || params.csv_pairs || params.csv_singles || params.read_pairs || params.read_singles || params.fastas || params.bam || params.tenx_tgz
 
 // Parameters for testing

--- a/main.nf
+++ b/main.nf
@@ -354,7 +354,7 @@ if (!protein_input) {
       .ifEmpty{  exit 1, "No reads provided! Check read input files" }
       .set { subsample_reads_ch }
   }
-  if (params.skip_trimming) {
+  if (params.skip_trimming && !(params.bam || params.tenx_tgz)) {
     reads_ch_unchecked
       .ifEmpty{ exit 1, "No reads provided! Check read input files" }
       .set { reads_ch }

--- a/main.nf
+++ b/main.nf
@@ -877,14 +877,11 @@ if ( have_nucleotide_input ) {
   if (params.subsample){
     // Concatenate trimmed reads with fastas for subsequent subsampling
     subsample_ch_reads_for_ribosomal_removal = ch_reads_trimmed.concat(fastas_ch)
+  } else {
+      // Concatenate trimmed reads with fastas for signature generation
+      ch_reads_for_ribosomal_removal = ch_reads_trimmed.concat(fastas_ch)
+    }
   }
-  else {
-    // Concatenate trimmed reads with fastas for signature generation
-    ch_reads_for_ribosomal_removal = ch_reads_trimmed.concat(fastas_ch)
-  }
-} else {
-  ch_fastp_results = Channel.from(false)
-}
 
   if (params.subsample) {
       process subsample_input {
@@ -998,7 +995,7 @@ if (!params.remove_ribo_rna) {
             """
         }
     }
-}
+  }
 
 
 
@@ -1120,6 +1117,18 @@ if (!params.remove_ribo_rna) {
   sourmash_sketches_nucleotide = Channel.empty()
   ch_protein_fastas
     .set { ch_translated_protein_seqs_nonempty }
+}
+
+
+
+if ((!have_nucleotide_input) || params.skip_trimming || have_nucleotide_fasta_input) {
+  // Only protein input or skip trimming, or fastas which can't be trimmed.
+  ch_fastp_results = Channel.from(false)
+}
+
+if (!have_nucleotide_input) {
+  // Only protein input, can't do sortMeRNA
+  sortmerna_logs = Channel.empty()
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -134,6 +134,7 @@ profiles {
   test { includeConfig 'conf/test.config' }
   test_ska { includeConfig 'conf/test_ska.config' }
   test_bam { includeConfig 'conf/test_bam.config' }
+  test_protein_fastas { includeConfig 'conf/test_protein_fastas.config' }
   test_tenx_tgz { includeConfig 'conf/test_tenx_tgz.config' }
   test_translate { includeConfig 'conf/test_translate.config' }
   test_translate_bam { includeConfig 'conf/test_translate_bam.config' }

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,7 @@ params {
   csv_pairs = false
   csv_singles = false
   fastas = false
+  protein_fastas = false
   sra = false
 
   // Parsing 10x bam files
@@ -36,7 +37,7 @@ params {
   // translate options
   translate_peptide_ksize = 7
   translate_peptide_molecule = 'protein'
-  peptide_fasta = false
+  reference_proteome_fasta = false
   bloomfilter_tablesize = '1e8'
   translate_jaccard_threshold = 0.8
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,12 +12,15 @@ params {
   read_singles = false
   samples = false
   samples_singles = false
-  read_paths = false
   csv_pairs = false
   csv_singles = false
   fastas = false
   protein_fastas = false
   sra = false
+
+  // Only used for testing
+  protein_fasta_paths
+  read_paths = false
 
   // Parsing 10x bam files
   tenx_tgz = false
@@ -35,11 +38,12 @@ params {
   skip_trimming = false
 
   // translate options
-  translate_peptide_ksize = 7
+  translate_peptide_ksize = 9
   translate_peptide_molecule = 'protein'
+  translate_jaccard_threshold = 0.95
   reference_proteome_fasta = false
   bloomfilter_tablesize = '1e8'
-  translate_jaccard_threshold = 0.8
+
 
 
   // ska options

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,7 +19,7 @@ params {
   sra = false
 
   // Only used for testing
-  protein_fasta_paths
+  protein_fasta_paths = false
   read_paths = false
 
   // Parsing 10x bam files

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,6 +19,7 @@ params {
   sra = false
 
   // Only used for testing
+  fasta_paths = false
   protein_fasta_paths = false
   read_paths = false
 
@@ -138,6 +139,7 @@ profiles {
   test { includeConfig 'conf/test.config' }
   test_ska { includeConfig 'conf/test_ska.config' }
   test_bam { includeConfig 'conf/test_bam.config' }
+  test_fastas { includeConfig 'conf/test_fastas.config' }
   test_protein_fastas { includeConfig 'conf/test_protein_fastas.config' }
   test_tenx_tgz { includeConfig 'conf/test_tenx_tgz.config' }
   test_translate { includeConfig 'conf/test_translate.config' }


### PR DESCRIPTION
Addresses https://github.com/nf-core/kmermaid/issues/72

Adds:

- `--protein_fastas` as input option
- Renames `--peptide_fasta` --> `--reference_proteome_fasta` for clarity and distinction from input protein fastas

## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/kmermaid branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/kmermaid)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [x] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/kmermaid/tree/master/.github/CONTRIBUTING.md
