### PR TITLE
Dependencies for removing ribosomal reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@
 ### Dependency Updates
 
 * Add samtools, screed, tqdm to dependencies
+* Add sortmerna=2.1b # for metatranscriptomics
+* Update sourmash to version 3.2.2
 
-## v1.0 - 6 March 2019
+## v0.1.0 - 6 March 2019
+
+Initial release of nf-core/kmermaid, created with the [nf-core](http://nf-co.re/) template.
 
 * Add option to use Dayhoff encoding for sourmash.
 * Add `bam2fasta` process to kmermaid pipeline and flags involved.
@@ -36,8 +40,3 @@ barcode fastq
 * Update Dockerfile with sourmash compute bam input dependencies
 * Add `track_abundance` feature to keep track of hashed kmer frequency.
 * Add [`czbiohub/bam2fasta`](https://github.com/czbiohub/bam2fasta/) repo to environment.yml
-* Update sourmash to version 3.2.2
-
-## v0.1.0 - 6 March 2019
-
-Initial release of nf-core/kmermaid, created with the [nf-core](http://nf-co.re/) template.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nfcore/base:1.7
+FROM nfcore/base:1.9
 LABEL description="Docker image containing all requirements for nf-core/kmermaid pipeline"
 
 # Suggested tags from https://microbadger.com/labels

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - sphinx=2.3.1
   - jupyter=1.0.0
   - conda-forge::s3fs=0.4.2
+  - sortmerna=2.1b # for metatranscriptomics
   - pip:
     - git+https://github.com/czbiohub/bam2fasta.git@master#egg=bam2fasta # master
     - git+https://github.com/czbiohub/sencha.git@master#egg=sencha # master - need to fix the version

--- a/environment.yml
+++ b/environment.yml
@@ -36,4 +36,3 @@ dependencies:
   - pip:
     - git+https://github.com/czbiohub/bam2fasta.git@master#egg=bam2fasta # master
     - git+https://github.com/czbiohub/sencha.git@master#egg=sencha # master - need to fix the version
-    - git+https://github.com/czbiohub/sourmash.git@master#egg=sourmash==3.2.0


### PR DESCRIPTION

Adds sortMeRNA dependency from nf-core/rnaseq dev to remove ribosomal reads

https://github.com/nf-core/rnaseq/blob/4dc6d37cf3a0b338a74e19f38ae1f26ff5c4a65e/environment.yml#L34

## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] `CHANGELOG.md` is updated

**Learn more about contributing:** https://github.com/nf-core/kmermaid/tree/master/.github/CONTRIBUTING.md
