### PR TITLE
Add option to remove ribosomal reads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   - name: "Latest Nextflow version, regular test suite"
     env: NXF_VER='' SUITE=test FLAGS=
   - name: "Text nextflow kmermaid, with removing ribosomal reads"
-    env: NXF_VER='' SUITE=test FLAGS=--remove_ribo_rna
+    env: NXF_VER='' SUITE=test_remove_ribo FLAGS=--remove_ribo_rna
   - name: "Test nextflow kmermaid, with --track_abundance"
     env: NXF_VER='' SUITE=test FLAGS='--track_abundance'
   - name: "Test nextflow kmermaid, with translate on fastas"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
     jdk: openjdk8
   - name: "Latest Nextflow version, regular test suite"
     env: NXF_VER='' SUITE=test FLAGS=
+  - name: "Text nextflow kmermaid, with removing ribosomal reads"
+    env: NXF_VER='' SUITE=test FLAGS=--remove_ribo_rna
   - name: "Test nextflow kmermaid, with --track_abundance"
     env: NXF_VER='' SUITE=test FLAGS='--track_abundance'
   - name: "Test nextflow kmermaid, with translate on fastas"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Pipeline enhancements & Fixes
 
 * Add option to use Dayhoff encoding for sourmash
+* Add option to remove ribosomal RNA using sortMeRNA ([#74](https://github.com/nf-core/kmermaid/issues/74))
 
 ### Dependency Updates
 

--- a/assets/rrna-db-defaults.txt
+++ b/assets/rrna-db-defaults.txt
@@ -1,0 +1,8 @@
+https://raw.githubusercontent.com/biocore/sortmerna/master/data/rRNA_databases/rfam-5.8s-database-id98.fasta
+https://raw.githubusercontent.com/biocore/sortmerna/master/data/rRNA_databases/rfam-5s-database-id98.fasta
+https://raw.githubusercontent.com/biocore/sortmerna/master/data/rRNA_databases/silva-arc-16s-id95.fasta
+https://raw.githubusercontent.com/biocore/sortmerna/master/data/rRNA_databases/silva-arc-23s-id98.fasta
+https://raw.githubusercontent.com/biocore/sortmerna/master/data/rRNA_databases/silva-bac-16s-id90.fasta
+https://raw.githubusercontent.com/biocore/sortmerna/master/data/rRNA_databases/silva-bac-23s-id98.fasta
+https://raw.githubusercontent.com/biocore/sortmerna/master/data/rRNA_databases/silva-euk-18s-id95.fasta
+https://raw.githubusercontent.com/biocore/sortmerna/master/data/rRNA_databases/silva-euk-28s-id98.fasta

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -8,17 +8,22 @@ import re
 regexes = {
     'nf-core/kmermaid': ['v_pipeline.txt', r"(\S+)"],
     'Nextflow': ['v_nextflow.txt', r"(\S+)"],
-    'Sourmash': ['v_sourmash.txt', r"sourmash version (\S+)"],
     'Bam2fasta': ['v_bam2fasta.txt', r"bam2fasta version (\S+)"],
     'fastp': ['v_fastp.txt', r"fastp (\S+)"],
+    'Samtools': ['v_samtools.txt', r"samtools (\S+)"],
+    'SKA': ['v_ska.txt', r"Version (\S+)"],
+    'htslib': ['v_samtools.txt', r"htslib (\S+)"],
+    'Sourmash': ['v_sourmash.txt', r"sourmash (\S+)"],
     'SortMeRNA': ['v_sortmerna.txt', r"SortMeRNA version (\S+),"],
 }
 results = OrderedDict()
 results['nf-core/kmermaid'] = '<span style="color:#999999;">N/A</span>'
 results['Nextflow'] = '<span style="color:#999999;">N/A</span>'
-results['Sourmash'] = '<span style="color:#999999;">N/A</span>'
 results['bam2fasta'] = '<span style="color:#999999;">N/A</span>'
 results['fastp'] = '<span style="color:#999999;">N/A</span>'
+results['Samtools'] = '<span style="color:#999999;">N/A</span>'
+results['SKA'] = '<span style="color:#999999;">N/A</span>'
+results['Sourmash'] = '<span style="color:#999999;">N/A</span>'
 results['SortMeRNA'] = '<span style="color:#999999;">N/A</span>'
 
 # Search each file using its regex
@@ -32,11 +37,6 @@ for k, v in regexes.items():
     except IOError:
         results[k] = False
 
-
-# Remove software set to false in results
-for k in results:
-    if not results[k]:
-        del(results[k])
 
 # Dump to YAML
 print ('''

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -10,16 +10,27 @@ regexes = {
     'Nextflow': ['v_nextflow.txt', r"(\S+)"],
     'Sourmash': ['v_sourmash.txt', r"sourmash version (\S+)"],
     'Bam2fasta': ['v_bam2fasta.txt', r"bam2fasta version (\S+)"],
+    'fastp': ['v_fastp.txt', r"fastp (\S+)"],
+    'SortMeRNA': ['v_sortmerna.txt', r"SortMeRNA version (\S+),"],
 }
 results = OrderedDict()
+results['nf-core/kmermaid'] = '<span style="color:#999999;">N/A</span>'
+results['Nextflow'] = '<span style="color:#999999;">N/A</span>'
+results['Sourmash'] = '<span style="color:#999999;">N/A</span>'
+results['bam2fasta'] = '<span style="color:#999999;">N/A</span>'
+results['fastp'] = '<span style="color:#999999;">N/A</span>'
+results['SortMeRNA'] = '<span style="color:#999999;">N/A</span>'
 
 # Search each file using its regex
 for k, v in regexes.items():
-    with open(v[0]) as x:
-        versions = x.read()
-        match = re.search(v[1], versions)
-        if match:
-            results[k] = "v{}".format(match.group(1))
+    try:
+        with open(v[0]) as x:
+            versions = x.read()
+            match = re.search(v[1], versions)
+            if match:
+                results[k] = "v{}".format(match.group(1))
+    except IOError:
+        results[k] = False
 
 
 # Remove software set to false in results

--- a/conf/test_remove_ribo.config
+++ b/conf/test_remove_ribo.config
@@ -23,6 +23,7 @@ params {
   // read_pairs = 'testing/fastqs/*{1,2}.fastq.gz'
   // sra = "SRP016501"
   remove_ribo_rna = true
+  save_non_rrna_reads = true
   read_paths = [
     ['SRR4050379', ['https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050379_pass_1.fastq.gz',
                     'https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050379_pass_2.fastq.gz']],

--- a/conf/test_remove_ribo.config
+++ b/conf/test_remove_ribo.config
@@ -1,0 +1,34 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/kmermaid -profile test
+ */
+
+params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on Travis
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+  // Input data
+  // samples = 'testing/samples.csv'
+  // fastas = 'testing/fastas/*.fasta'
+  ksizes = '3,9'
+  log2_sketch_sizes = '2,4'
+  molecules = 'dna,protein,dayhoff'
+  // read_pairs = 'testing/fastqs/*{1,2}.fastq.gz'
+  // sra = "SRP016501"
+  remove_ribo_rna = true
+  read_paths = [
+    ['SRR4050379', ['https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050379_pass_1.fastq.gz',
+                    'https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050379_pass_2.fastq.gz']],
+    ['SRR4050380', ['https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050380_pass_1.fastq.gz',
+                    'https://github.com/nf-core/test-datasets/raw/kmermaid/testdata/SRR4050380_pass_2.fastq.gz']],
+    ['SRR4238351', ['https://github.com/nf-core/test-datasets/raw/rnaseq/testdata/SRR4238351_subsamp.fastq.gz']],
+    ['SRR4238355', ['https://github.com/nf-core/test-datasets/raw/rnaseq/testdata/SRR4238355_subsamp.fastq.gz']],
+  ]
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,31 +12,35 @@
         * [`awsbatch`](#awsbatch)
         * [`standard`](#standard)
         * [`none`](#none)
-    * [Read inputs](#read-inputs)
-        * [`--read_pairs`](#--read_pairs)
-        * [`--read_singles`](#--read_singles)
-        * [`--csv_pairs`](#--csv_pairs)
-        * [`--csv_singles`](#--csv_singles)
-        * [`--fastas`](#--fastas)
-        * [`--sra`](#--sra)
-        * [`--bam`](#--bam)
-        * [`--barcodes_file`](#--barcodes_file)
-        * [`--rename_10x_barcodes`](#--rename_10x_barcodes)
-        * [`--save_fastas`](#--save_fastas)
-    * [Adapter Trimming][#adapter-trimming]
-        * [`--skip_trimming`](#--skip_trimming)
-    * [K-merization/Sketching program options](#k-merization-sketching-program-options)
-        * [`--splitKmer`](#--splitKmer)
-    * [Sketch parameters](#sketch-parameters)
-        * [`--molecule`](#--molecule)
-        * [`--ksize`](#--ksize)
-        * [`--log2_sketch_size`](#--log2_sketch_size)
-        * [`--track_abundance`](#--track_abundance)
-    * [Bam optional parameters](#bam-optional-parameters)
-        * [`--tenx_min_umi_per_cell`](#--tenx_min_umi_per_cell)
-        * [`--write_barcode_meta_csv`](#--write_barcode_meta_csv)
-        * [`--shard_size`](#--shard_size)
-
+* [Read inputs](#read-inputs)
+    * [`--read_pairs`](#--read_pairs)
+    * [`--read_singles`](#--read_singles)
+    * [`--csv_pairs`](#--csv_pairs)
+    * [`--csv_singles`](#--csv_singles)
+    * [`--fastas`](#--fastas)
+    * [`--sra`](#--sra)
+    * [`--bam`](#--bam)
+    * [`--barcodes_file`](#--barcodes_file)
+    * [`--rename_10x_barcodes`](#--rename_10x_barcodes)
+    * [`--save_fastas`](#--save_fastas)
+* [Adapter Trimming][#adapter-trimming]
+    * [`--skip_trimming`](#--skip_trimming)
+* [K-merization/Sketching program options](#k-merization-sketching-program-options)
+* [Ribosomal RNA removal](#ribosomal-rna-removal)
+  * [`--removeRiboRNA`](#removeriborna)
+  * [`--saveNonRiboRNAReads`](#savenonribornareads)
+  * [`--rRNA_database_manifest`](#rrnadatabasemanifest)
+- [Library Prep Presets](#library-prep-presets)
+    * [`--splitKmer`](#--splitKmer)
+* [Sketch parameters](#sketch-parameters)
+    * [`--molecule`](#--molecule)
+    * [`--ksize`](#--ksize)
+    * [`--log2_sketch_size`](#--log2_sketch_size)
+    * [`--track_abundance`](#--track_abundance)
+* [Bam optional parameters](#bam-optional-parameters)
+    * [`--tenx_min_umi_per_cell`](#--tenx_min_umi_per_cell)
+    * [`--write_barcode_meta_csv`](#--write_barcode_meta_csv)
+    * [`--shard_size`](#--shard_size)
 * [Job Resources](#job-resources)
 * [Automatic resubmission](#automatic-resubmission)
 * [Custom resource requests](#custom-resource-requests)
@@ -230,6 +234,26 @@ used to launch fastp!
 ### `--skip_trimming`
 
 This allows to skip the trimming process to save time when re-analyzing data that has been trimmed already.
+
+## Ribosomal RNA removal
+
+If rRNA removal is desired (for example, metatranscriptomics),
+add the following command line parameters.
+Please be adviced that by default these steps make use of the SILVA v119 database that requires [`licencing for commercial/non-academic entities`](https://www.arb-silva.de/silva-license-information).
+
+### `--removeRiboRNA`
+
+Instructs to use SortMeRNA to remove reads related to ribosomal RNA (or any patterns found in the sequences defined by `--rRNA_database_manifest`).
+
+### `--saveNonRiboRNAReads`
+
+By default, non-rRNA FastQ files will not be saved to the results directory. Specify this
+flag (or set to true in your config file) to copy these files when complete.
+
+### `--rRNA_database_manifest`
+
+By default, rRNA databases in github [`biocore/sortmerna/rRNA_databases`](https://github.com/biocore/sortmerna/tree/master/data/rRNA_databases) are used. Here the path to a text file can be provided that contains paths to fasta files (one per line, no ' or " for file names) that will be used for database creation for SortMeRNA instead of the default ones. You can see an example in the directory `assets/rrna-default-dbs.txt`. Consequently, similar reads to these sequences will be removed.
+Be aware that commercial/non-academic entities require [`licensing for SILVA`](https://www.arb-silva.de/silva-license-information) with these default databases.
 
 ## K-merization/Sketching program Options
 

--- a/main.nf
+++ b/main.nf
@@ -794,6 +794,8 @@ if (!params.skip_trimming){
     // Concatenate trimmed reads with fastas for signature generation
     ch_reads_for_ribosomal_removal = ch_reads_trimmed.concat(fastas_ch)
   }
+} else {
+  ch_fastp_results = Channel.from(false)
 }
 
 if (params.subsample) {

--- a/main.nf
+++ b/main.nf
@@ -874,7 +874,8 @@ if (!params.remove_ribo_rna) {
         for (i=0; i<db_fasta.size(); i++) { Refs+= ":${db_fasta[i]},${db_name[i]}" }
         Refs = Refs.substring(1)
 
-        if (params.single_end) {
+        // One set of reads --> single end
+        if (reads[1] == null) {
             """
             gzip -d --force < ${reads} > all-reads.fastq
             sortmerna --ref ${Refs} \

--- a/main.nf
+++ b/main.nf
@@ -270,7 +270,7 @@ if (params.subsample) {
       sra_ch.concat(csv_pairs_ch, csv_singles_ch, read_pairs_ch,
         read_singles_ch, fastas_ch, read_paths_ch)
         .ifEmpty{ exit 1, "No reads provided! Check read input files"}
-        .set{ subsample_reads_ch }
+        .set{ subsample_ch_reads_for_ribosomal_removal }
     } else {
       sra_ch.concat(
           csv_pairs_ch, csv_singles_ch, read_pairs_ch,
@@ -286,7 +286,7 @@ if (params.subsample) {
           csv_pairs_ch, csv_singles_ch, read_pairs_ch,
           read_singles_ch, fastas_ch, read_paths_ch)
        .ifEmpty{ exit 1, "No reads provided! Check read input files"}
-       .set{ reads_ch }
+       .set{ ch_reads_for_ribosomal_removal }
     } else {
       if (params.fastas) {
         // With fasta files - combine everything that can be trimmed
@@ -338,6 +338,16 @@ if (params.splitKmer){
     params.ksizes = '21,27,33,51'
 }
 
+// Get rRNA databases
+// Default is set to bundled DB list in `assets/rrna-db-defaults.txt`
+
+rRNA_database = file(params.rRNA_database_manifest)
+if (rRNA_database.isEmpty()) {exit 1, "File ${rRNA_database.getName()} is empty!"}
+Channel
+    .from( rRNA_database.readLines() )
+    .map { row -> file(row) }
+    .set { sortmerna_fasta }
+
 
 // Parse the parameters
 
@@ -378,6 +388,12 @@ if (!params.write_barcode_meta_csv) {
 else {
   barcode_metadata_folder = "barcode_metadata"
 }
+
+
+// Stage config files
+ch_multiqc_config = file("$baseDir/assets/multiqc_config.yaml", checkIfExists: true)
+ch_multiqc_custom_config = params.multiqc_config ? Channel.fromPath(params.multiqc_config, checkIfExists: true) : Channel.empty()
+ch_output_docs = file("$baseDir/docs/output.md", checkIfExists: true)
 
 // Header log info
 log.info nfcoreHeader()
@@ -456,6 +472,24 @@ ${summary.collect { k,v -> "            <dt>$k</dt><dd><samp>${v ?: '<span style
 }
 
 
+Channel.from(summary.collect{ [it.key, it.value] })
+    .map { k,v -> "<dt>$k</dt><dd><samp>${v ?: '<span style=\"color:#999999;\">N/A</a>'}</samp></dd>" }
+    .reduce { a, b -> return [a, b].join("\n            ") }
+    .map { x -> """
+    id: 'nf-core-kmermaid-summary'
+    description: " - this information is collected when the pipeline is started."
+    section_name: 'nf-core/kmermaid Workflow Summary'
+    section_href: 'https://github.com/nf-core/kmermaid'
+    plot_type: 'html'
+    data: |
+        <dl class=\"dl-horizontal\">
+            $x
+        </dl>
+    """.stripIndent() }
+    .set { ch_workflow_summary }
+
+
+
 /*
  * Parse software version numbers
  */
@@ -467,14 +501,15 @@ process get_software_versions {
     }
 
     output:
-    file 'software_versions_mqc.yaml' into software_versions_yaml
+    file 'software_versions_mqc.yaml' into ch_software_versions_yaml
     file "software_versions.csv"
 
     script:
     """
     echo $workflow.manifest.version > v_pipeline.txt
     echo $workflow.nextflow.version > v_nextflow.txt
-    sourmash info &> v_sourmash.txt
+    fastp --version &> v_fastp.txt
+    sortmerna --version &> v_sortmerna.txt
     bam2fasta info &> v_bam2fasta.txt
     scrape_software_versions.py &> software_versions_mqc.yaml
     """
@@ -589,8 +624,8 @@ if (params.tenx_tgz || params.bam) {
 
   // Put fastqs from aligned and unaligned reads into a single channel
   tenx_reads_aligned_concatenation_ch.mix(tenx_reads_unaligned_ch)
-    .dump(tag: "tenx_reads_ch")
-    .set{ tenx_reads_ch }
+    .dump(tag: "tenx_ch_reads_for_ribosomal_removal")
+    .set{ tenx_ch_reads_for_ribosomal_removal }
 
   if ((params.tenx_min_umi_per_cell > 0) || !params.barcodes_file) {
     process count_umis_per_cell {
@@ -611,7 +646,7 @@ if (params.tenx_tgz || params.bam) {
       umis_per_cell = "${is_aligned_channel_id}__n_umi_per_cell.csv"
       good_barcodes = "${is_aligned_channel_id}__barcodes.tsv"
 
-      """  
+      """
         bam2fasta count_umis_percell \\
             --filename ${reads} \\
             --min-umi-per-barcode ${tenx_min_umi_per_cell} \\
@@ -636,8 +671,8 @@ if (params.tenx_tgz || params.bam) {
     good_barcodes_ch = tenx_bam_barcodes_ch
   }
 
-  tenx_reads_ch.combine(good_barcodes_ch, by: 0)
-    .dump(tag: 'tenx_reads_ch__combine__good_barcodes_ch')
+  tenx_ch_reads_for_ribosomal_removal.combine(good_barcodes_ch, by: 0)
+    .dump(tag: 'tenx_ch_reads_for_ribosomal_removal__combine__good_barcodes_ch')
     .set{ tenx_reads_with_good_barcodes_ch }
 
   process extract_per_cell_fastqs {
@@ -651,7 +686,7 @@ if (params.tenx_tgz || params.bam) {
     set val(channel_id), val(is_aligned), file(reads), file(barcodes) from tenx_reads_with_good_barcodes_ch
 
     output:
-    file('*.fastq.gz') into per_channel_cell_reads_ch
+    file('*.fastq.gz') into per_channel_cell_ch_reads_for_ribosomal_removal
 
     script:
     is_aligned_channel_id = "${channel_id}__${is_aligned}__"
@@ -672,11 +707,11 @@ if (params.tenx_tgz || params.bam) {
     """
   }
   // Make per-cell fastqs into a flat channel that matches the read channels of yore
-  // Filtering out fastq.gz files less than 200 bytes (arbitary number) 
+  // Filtering out fastq.gz files less than 200 bytes (arbitary number)
   // ~200 bytes is about the size of a file with a single read or less
   // We can't use .size() > 0 because it's fastq.gz is gzipped content
-  per_channel_cell_reads_ch
-    .dump(tag: 'per_channel_cell_reads_ch')
+  per_channel_cell_ch_reads_for_ribosomal_removal
+    .dump(tag: 'per_channel_cell_ch_reads_for_ribosomal_removal')
     .flatten()
     .filter{ it -> it.size() > 200 }   // each item is just a single file, no need to do it[1]
     .map{ it -> tuple(it.simpleName, file(it)) }
@@ -684,7 +719,7 @@ if (params.tenx_tgz || params.bam) {
     .set{ per_cell_fastqs_ch }
 
   if (params.skip_trimming) {
-    reads_ch = ch_non_bam_reads.concat(per_cell_fastqs_ch)
+    ch_reads_for_ribosomal_removal = ch_non_bam_reads.concat(per_cell_fastqs_ch)
   } else {
     ch_read_files_trimming = ch_non_bam_reads.concat(per_cell_fastqs_ch)
   }
@@ -742,7 +777,7 @@ if (!params.skip_trimming){
       }
   }
 
-  // Filtering out fastq.gz files less than 200 bytes (arbitary number) 
+  // Filtering out fastq.gz files less than 200 bytes (arbitary number)
   // ~200 bytes is about the size of a file with a single read or less
   // We can't use .size() > 0 because it's fastq.gz is gzipped content
   ch_reads_all_trimmed.filter{ it -> it[1].size() > 200 }
@@ -750,11 +785,11 @@ if (!params.skip_trimming){
   // Concatenate trimmed fastq files with fastas
   if (params.subsample){
     // Concatenate trimmed reads with fastas for subsequent subsampling
-    subsample_reads_ch = ch_reads_trimmed.concat(fastas_ch)
-  } 
+    subsample_ch_reads_for_ribosomal_removal = ch_reads_trimmed.concat(fastas_ch)
+  }
   else {
     // Concatenate trimmed reads with fastas for signature generation
-    reads_ch = ch_reads_trimmed.concat(fastas_ch)
+    ch_reads_for_ribosomal_removal = ch_reads_trimmed.concat(fastas_ch)
   }
 }
 
@@ -764,11 +799,11 @@ if (params.subsample) {
 	publishDir "${params.outdir}/seqtk/", mode: 'copy'
 
 	input:
-	set id, file(reads) from subsample_reads_ch
+	set id, file(reads) from subsample_ch_reads_for_ribosomal_removal
 
 	output:
 
-	set val(id), file("*_${params.subsample}.fastq.gz") into reads_ch
+	set val(id), file("*_${params.subsample}.fastq.gz") into ch_reads_for_ribosomal_removal
 
 	script:
 	read1 = reads[0]
@@ -781,6 +816,95 @@ if (params.subsample) {
   seqtk sample -s100 ${read2} ${params.subsample} > ${read2_prefix}_${params.subsample}.fastq.gz
   """
   }
+}
+
+/*
+ * STEP 2+ - SortMeRNA - remove rRNA sequences on request
+ */
+if (!params.removeRiboRNA) {
+    ch_reads_for_ribosomal_removal
+        .into { reads_ch }
+    sortmerna_logs = Channel.empty()
+} else {
+    process sortmerna_index {
+        label 'low_memory'
+        tag "${fasta.baseName}"
+
+        input:
+        file(fasta) from sortmerna_fasta
+
+        output:
+        val("${fasta.baseName}") into sortmerna_db_name
+        file("$fasta") into sortmerna_db_fasta
+        file("${fasta.baseName}*") into sortmerna_db
+
+        script:
+        """
+        indexdb_rna --ref $fasta,${fasta.baseName} -m 3072 -v
+        """
+    }
+
+    process sortmerna {
+        label 'low_memory'
+        tag "$name"
+        publishDir "${params.outdir}/SortMeRNA", mode: "${params.publish_dir_mode}",
+            saveAs: {filename ->
+                if (filename.indexOf("_rRNA_report.txt") > 0) "logs/$filename"
+                else if (params.saveNonRiboRNAReads) "reads/$filename"
+                else null
+            }
+
+        input:
+        set val(name), file(reads) from ch_reads_for_ribosomal_removal
+        val(db_name) from sortmerna_db_name.collect()
+        file(db_fasta) from sortmerna_db_fasta.collect()
+        file(db) from sortmerna_db.collect()
+
+        output:
+        set val(name), file("*.fq.gz") into reads_ch
+        file "*_rRNA_report.txt" into sortmerna_logs
+
+
+        script:
+        //concatenate reference files: ${db_fasta},${db_name}:${db_fasta},${db_name}:...
+        def Refs = ''
+        for (i=0; i<db_fasta.size(); i++) { Refs+= ":${db_fasta[i]},${db_name[i]}" }
+        Refs = Refs.substring(1)
+
+        if (params.single_end) {
+            """
+            gzip -d --force < ${reads} > all-reads.fastq
+            sortmerna --ref ${Refs} \
+                --reads all-reads.fastq \
+                --num_alignments 1 \
+                -a ${task.cpus} \
+                --fastx \
+                --aligned rRNA-reads \
+                --other non-rRNA-reads \
+                --log -v
+            gzip --force < non-rRNA-reads.fastq > ${name}.fq.gz
+            mv rRNA-reads.log ${name}_rRNA_report.txt
+            """
+        } else {
+            """
+            gzip -d --force < ${reads[0]} > reads-fw.fq
+            gzip -d --force < ${reads[1]} > reads-rv.fq
+            merge-paired-reads.sh reads-fw.fq reads-rv.fq all-reads.fastq
+            sortmerna --ref ${Refs} \
+                --reads all-reads.fastq \
+                --num_alignments 1 \
+                -a ${task.cpus} \
+                --fastx --paired_in \
+                --aligned rRNA-reads \
+                --other non-rRNA-reads \
+                --log -v
+            unmerge-paired-reads.sh non-rRNA-reads.fastq non-rRNA-reads-fw.fq non-rRNA-reads-rv.fq
+            gzip < non-rRNA-reads-fw.fq > ${name}-fw.fq.gz
+            gzip < non-rRNA-reads-rv.fq > ${name}-rv.fq.gz
+            mv rRNA-reads.log ${name}_rRNA_report.txt
+            """
+        }
+    }
 }
 
 
@@ -984,6 +1108,42 @@ if (params.splitKmer){
 
   }
 }
+
+
+/*
+ * STEP 16 - MultiQC
+ */
+process multiqc {
+    publishDir "${params.outdir}/MultiQC", mode: "${params.publish_dir_mode}"
+
+    when:
+    !params.skipMultiQC
+
+    input:
+    file multiqc_config from ch_multiqc_config
+    file (mqc_custom_config) from ch_multiqc_custom_config.collect().ifEmpty([])
+    file ('fastp/*') from ch_fastp_results.collect().ifEmpty([])
+    file ('sortmerna/*') from sortmerna_logs.collect().ifEmpty([])
+    file ('software_versions/*') from ch_software_versions_yaml.collect()
+    file workflow_summary from ch_workflow_summary.collectFile(name: "workflow_summary_mqc.yaml")
+
+    output:
+    file "*multiqc_report.html" into ch_multiqc_report
+    file "*_data"
+    file "multiqc_plots"
+
+    script:
+    rtitle = custom_runName ? "--title \"$custom_runName\"" : ''
+    rfilename = custom_runName ? "--filename " + custom_runName.replaceAll('\\W','_').replaceAll('_+','_') + "_multiqc_report" : ''
+    custom_config_file = params.multiqc_config ? "--config $mqc_custom_config" : ''
+    """
+    multiqc . -f $rtitle $rfilename $custom_config_file \\
+        -m custom_content \\
+        -m fastp \\
+        -m sortmerna
+    """
+}
+
 
 
 /*

--- a/main.nf
+++ b/main.nf
@@ -1121,7 +1121,7 @@ process multiqc {
     publishDir "${params.outdir}/MultiQC", mode: "${params.publish_dir_mode}"
 
     when:
-    !params.skipMultiQC
+    !params.skip_multiqc
 
     input:
     file multiqc_config from ch_multiqc_config

--- a/main.nf
+++ b/main.nf
@@ -692,7 +692,7 @@ if (params.tenx_tgz || params.bam) {
     file('*.fastq.gz') into per_channel_cell_ch_reads_for_ribosomal_removal
 
     script:
-    is_aligned_channel_id = "${channel_id}__${is_aligned}__"
+    is_aligned_channel_id = "${channel_id}__${is_aligned}"
     def rename_10x_barcodes = params.rename_10x_barcodes ? "--rename-10x-barcodes ${rename_10x_barcodes.baseName}.tsv": ''
     processes = "--processes ${task.cpus}"
     """
@@ -702,7 +702,7 @@ if (params.tenx_tgz || params.bam) {
         --barcodes-significant-umis-fil ${barcodes} \\
         $rename_10x_barcodes \\
         --cell-barcode-pattern '${tenx_cell_barcode_pattern}' \\
-        --channel-id ${is_aligned_channel_id} \\
+        --channel-id ${is_aligned_channel_id}__ \\
         --output-format 'fastq.gz'
     # Decoy file just in case there are no reads found,
     # to prevent this process from erroring out

--- a/main.nf
+++ b/main.nf
@@ -508,9 +508,12 @@ process get_software_versions {
     """
     echo $workflow.manifest.version > v_pipeline.txt
     echo $workflow.nextflow.version > v_nextflow.txt
-    fastp --version &> v_fastp.txt
-    sortmerna --version &> v_sortmerna.txt
     bam2fasta info &> v_bam2fasta.txt
+    fastp --version &> v_fastp.txt
+    samtools --version &> v_samtools
+    ska version &> v_ska.txt
+    sortmerna --version &> v_sortmerna.txt
+    sourmash -v &> v_sourmash.txt
     scrape_software_versions.py &> software_versions_mqc.yaml
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -341,7 +341,7 @@ if (params.splitKmer){
 // Get rRNA databases
 // Default is set to bundled DB list in `assets/rrna-db-defaults.txt`
 
-rRNA_database = file(params.rRNA_database_manifest)
+rRNA_database = file(params.rrna_database_manifest)
 if (rRNA_database.isEmpty()) {exit 1, "File ${rRNA_database.getName()} is empty!"}
 Channel
     .from( rRNA_database.readLines() )
@@ -824,7 +824,7 @@ if (params.subsample) {
 /*
  * STEP 2+ - SortMeRNA - remove rRNA sequences on request
  */
-if (!params.remove_ribo_rnaRiboRNA) {
+if (!params.remove_ribo_rna) {
     ch_reads_for_ribosomal_removal
         .into { reads_ch }
     sortmerna_logs = Channel.empty()
@@ -1124,7 +1124,6 @@ process multiqc {
 
     input:
     file multiqc_config from ch_multiqc_config
-    file (mqc_custom_config) from ch_multiqc_custom_config.collect().ifEmpty([])
     file ('fastp/*') from ch_fastp_results.collect().ifEmpty([])
     file ('sortmerna/*') from sortmerna_logs.collect().ifEmpty([])
     file ('software_versions/*') from ch_software_versions_yaml.collect()

--- a/main.nf
+++ b/main.nf
@@ -824,7 +824,7 @@ if (params.subsample) {
 /*
  * STEP 2+ - SortMeRNA - remove rRNA sequences on request
  */
-if (!params.removeRiboRNA) {
+if (!params.remove_ribo_rnaRiboRNA) {
     ch_reads_for_ribosomal_removal
         .into { reads_ch }
     sortmerna_logs = Channel.empty()
@@ -853,7 +853,7 @@ if (!params.removeRiboRNA) {
         publishDir "${params.outdir}/SortMeRNA", mode: "${params.publish_dir_mode}",
             saveAs: {filename ->
                 if (filename.indexOf("_rRNA_report.txt") > 0) "logs/$filename"
-                else if (params.saveNonRiboRNAReads) "reads/$filename"
+                else if (params.save_non_rrna_reads) "reads/$filename"
                 else null
             }
 

--- a/main.nf
+++ b/main.nf
@@ -1138,7 +1138,7 @@ process multiqc {
     script:
     rtitle = custom_runName ? "--title \"$custom_runName\"" : ''
     rfilename = custom_runName ? "--filename " + custom_runName.replaceAll('\\W','_').replaceAll('_+','_') + "_multiqc_report" : ''
-    custom_config_file = params.multiqc_config ? "--config $mqc_custom_config" : ''
+    custom_config_file = params.multiqc_config ? "--config $multiqc_config" : ''
     """
     multiqc . -f $rtitle $rfilename $custom_config_file \\
         -m custom_content \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,9 +61,13 @@ params {
   rename_10x_barcodes = false
   shard_size = 350
 
+  // QC to skip
+  skip_multiqc = false
+
   // Boilerplate options
   outdir = './results'
   name = false
+  publish_dir_mode = 'copy'
   multiqc_config = "$baseDir/assets/multiqc_config.yaml"
   email = false
   plaintext_email = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -43,7 +43,7 @@ params {
   // Ribosomal RNA removal
   remove_ribo_rna = false
   save_non_rrna_reads = false
-  rRNA_database_manifest = "${baseDir}/assets/rrna-db-defaults.txt"
+  rrna_database_manifest = "${baseDir}/assets/rrna-db-defaults.txt"
 
   // ska options
   splitKmer = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -137,6 +137,7 @@ profiles {
   test { includeConfig 'conf/test.config' }
   test_ska { includeConfig 'conf/test_ska.config' }
   test_bam { includeConfig 'conf/test_bam.config' }
+  test_remove_ribo { includeConfig 'conf/test_remove_ribo.config' }
   test_tenx_tgz { includeConfig 'conf/test_tenx_tgz.config' }
   test_translate { includeConfig 'conf/test_translate.config' }
   test_translate_bam { includeConfig 'conf/test_translate_bam.config' }

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,6 +40,10 @@ params {
   bloomfilter_tablesize = '1e8'
   translate_jaccard_threshold = 0.8
 
+  // Ribosomal RNA removal
+  removeRiboRNA = true
+  save_nonrRNA_reads = false
+  rRNA_database_manifest = "${baseDir}/assets/rrna-db-defaults.txt"
 
   // ska options
   splitKmer = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -41,8 +41,8 @@ params {
   translate_jaccard_threshold = 0.8
 
   // Ribosomal RNA removal
-  removeRiboRNA = true
-  save_nonrRNA_reads = false
+  remove_ribo_rna = false
+  save_non_rrna_reads = false
   rRNA_database_manifest = "${baseDir}/assets/rrna-db-defaults.txt"
 
   // ska options


### PR DESCRIPTION
Addresses https://github.com/nf-core/kmermaid/issues/74 to remove ribosomal reads from the trimmed sequences, so that down the line the differential hash expression doesn't even have the option of looking at ribosomal abundance, which is usually more related to sequencing depth than biological function.

## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/kmermaid branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/kmermaid)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

