### PR TITLE
Increase CPUs for high_memory_long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ barcode fastq
 * Remove `one_signature_per_record` flag and add bam2fasta count_umis_percell and make_fastqs_percell instead of bam2fasta sharding method
 * Update renaming of `khtools` commands to `sencha`
 * Make sure `samtools_fastq_aligned` outputs ALL aligned reads, regardless of mapping quality or primary alignment status
+* Increase CPUs in `high_memory_long` profile from 1 to 10
 
 ### Dependency updates
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -40,6 +40,7 @@ process {
     time = { check_max( 48.h * task.attempt, 'time' ) }
   }
   withLabel: high_memory_long {
+    cpus = { check_max (10, 'cpus')}
     memory = { check_max( 80.GB * task.attempt, 'memory' ) }
     time = { check_max( 96.h * task.attempt, 'time' ) }
   }


### PR DESCRIPTION
Currently, `extract_per_cell_fastqs`/ `bam2fasta make_fastqs_percell` uses the `high_memory_long` process configuration, which uses only 1 process. This is taking a very long time to finish for me (been running since 2020-05-14 12:28:02). So this PR increases the CPUs from 1 to 10.

## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] `CHANGELOG.md` is updated

