### PR TITLE
Increase CPUs, memory, and time for SortMeRNA

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1079,7 +1079,8 @@ if (!params.remove_ribo_rna) {
     sortmerna_logs = Channel.empty()
 } else {
     process sortmerna_index {
-        label 'low_memory'
+        label 'mid_memory_long'
+        label 'mid_cpu'
         tag "${fasta.baseName}"
 
         input:
@@ -1097,7 +1098,8 @@ if (!params.remove_ribo_rna) {
     }
 
     process sortmerna {
-        label 'low_memory'
+        label 'mid_memory_long'
+        label 'mid_cpu'
         tag "$name"
         publishDir "${params.outdir}/SortMeRNA", mode: "${params.publish_dir_mode}",
             saveAs: {filename ->


### PR DESCRIPTION
cc @pranathivemuri and @phoenixAja -- this might help with getting SortMeRNA to run faster on the IBM machines. Currently the resource requirements are set to the lowest possible setting, and this increases to the `mid_memory_long` (32.GB memory, and 96h) `mid_cpu` (8 CPUs) settings.

This code was originally stolen from nf-core/rnaseq and there it gets the `process_high` label for higher requirements: https://github.com/nf-core/rnaseq/blob/a3222ce3010caf25c92f0c981de501a57cd583f6/modules/nf-core/software/sortmerna/main.nf#L6

If you're able to rebase your changes with this branch, then it shouldn't restart the pipeline from scratch because it only changes the resource requirements, not the pipeline script itself.

# nf-core/kmermaid pull request

Many thanks for contributing to nf-core/kmermaid!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/kmermaid branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/kmermaid)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/kmermaid/tree/master/.github/CONTRIBUTING.md)